### PR TITLE
✨[Feature] - 약물 관리 메인의 페이지 이동을 구현한다.

### DIFF
--- a/app/(tabs)/medicine/MedicineList.tsx
+++ b/app/(tabs)/medicine/MedicineList.tsx
@@ -1,0 +1,14 @@
+import React from "react";
+import { StyleSheet, Text, View } from "react-native";
+
+const medicineList = () => {
+  return (
+    <View>
+      <Text>medicineList</Text>
+    </View>
+  );
+};
+
+export default medicineList;
+
+const styles = StyleSheet.create({});

--- a/app/(tabs)/medicine/MedicineList.tsx
+++ b/app/(tabs)/medicine/MedicineList.tsx
@@ -1,11 +1,19 @@
+import { ScreenLayout } from "@/components/ScreenLayout";
+import Ionicons from "@expo/vector-icons/Ionicons";
+import { router } from "expo-router";
 import React from "react";
-import { StyleSheet, Text, View } from "react-native";
+import { StyleSheet, Text, TouchableOpacity, View } from "react-native";
 
 const medicineList = () => {
   return (
-    <View>
-      <Text>medicineList</Text>
-    </View>
+    <ScreenLayout>
+      <View>
+        <Text>medicineList</Text>
+      </View>
+      <TouchableOpacity onPress={() => router.back()}>
+        <Ionicons name="chevron-back" size={24} color={"black"} />
+      </TouchableOpacity>
+    </ScreenLayout>
   );
 };
 

--- a/app/(tabs)/medicine/Register.tsx
+++ b/app/(tabs)/medicine/Register.tsx
@@ -1,0 +1,14 @@
+import React from "react";
+import { StyleSheet, Text, View } from "react-native";
+
+const Register = () => {
+  return (
+    <View>
+      <Text>Register</Text>
+    </View>
+  );
+};
+
+export default Register;
+
+const styles = StyleSheet.create({});

--- a/app/(tabs)/medicine/Register.tsx
+++ b/app/(tabs)/medicine/Register.tsx
@@ -1,11 +1,19 @@
+import { ScreenLayout } from "@/components/ScreenLayout";
+import Ionicons from "@expo/vector-icons/Ionicons";
+import { router } from "expo-router";
 import React from "react";
-import { StyleSheet, Text, View } from "react-native";
+import { StyleSheet, Text, TouchableOpacity, View } from "react-native";
 
 const Register = () => {
   return (
-    <View>
-      <Text>Register</Text>
-    </View>
+    <ScreenLayout>
+      <View>
+        <Text>Register</Text>
+      </View>
+      <TouchableOpacity onPress={() => router.back()}>
+        <Ionicons name="chevron-back" size={24} color={"black"} />
+      </TouchableOpacity>
+    </ScreenLayout>
   );
 };
 

--- a/app/(tabs)/medicine/index.tsx
+++ b/app/(tabs)/medicine/index.tsx
@@ -1,13 +1,26 @@
 import NavigationCard from "@/components/NavigationCard";
 import { ScreenLayout } from "@/components/ScreenLayout";
+import { router } from "expo-router";
 import { StyleSheet, View } from "react-native";
 
 export default function MedicineScreen() {
   return (
     <ScreenLayout>
       <View style={styles.navCardContainer}>
-        <NavigationCard text="전체 복용약 보기" icon="next" />
-        <NavigationCard text="약물 등록하기" icon="plus" />
+        <NavigationCard
+          text="전체 복용약 보기"
+          icon="next"
+          onPress={() => {
+            router.push("/medicine/MedicineList");
+          }}
+        />
+        <NavigationCard
+          text="약물 등록하기"
+          icon="plus"
+          onPress={() => {
+            router.push("/medicine/Register");
+          }}
+        />
       </View>
     </ScreenLayout>
   );

--- a/app/(tabs)/medicine/index.tsx
+++ b/app/(tabs)/medicine/index.tsx
@@ -1,10 +1,22 @@
-import { Text } from "react-native";
-import { SafeAreaView } from "react-native-safe-area-context";
+import NavigationCard from "@/components/NavigationCard";
+import { ScreenLayout } from "@/components/ScreenLayout";
+import { StyleSheet, View } from "react-native";
 
 export default function MedicineScreen() {
   return (
-    <SafeAreaView>
-      <Text>약물관리 스크린</Text>
-    </SafeAreaView>
+    <ScreenLayout>
+      <View style={styles.navCardContainer}>
+        <NavigationCard text="전체 복용약 보기" icon="next" />
+        <NavigationCard text="약물 등록하기" icon="plus" />
+      </View>
+    </ScreenLayout>
   );
 }
+
+const styles = StyleSheet.create({
+  navCardContainer: {
+    flexDirection: "row",
+    justifyContent: "center",
+    gap: 20,
+  },
+});

--- a/app/(tabs)/medicine/index.tsx
+++ b/app/(tabs)/medicine/index.tsx
@@ -1,7 +1,7 @@
-import NavigationCard from "@/components/NavigationCard";
+import NavigationCard from "@/components/Card/NavigationCard";
 import { ScreenLayout } from "@/components/ScreenLayout";
 import { router } from "expo-router";
-import { StyleSheet, View } from "react-native";
+import { StyleSheet, Text, View } from "react-native";
 
 export default function MedicineScreen() {
   return (
@@ -22,6 +22,9 @@ export default function MedicineScreen() {
           }}
         />
       </View>
+      <View style={styles.todayContainer}>
+        <Text>Today's</Text>
+      </View>
     </ScreenLayout>
   );
 }
@@ -32,4 +35,5 @@ const styles = StyleSheet.create({
     justifyContent: "center",
     gap: 20,
   },
+  todayContainer: {},
 });

--- a/components/Card/GroupMedicineCard.tsx
+++ b/components/Card/GroupMedicineCard.tsx
@@ -1,0 +1,16 @@
+import React from "react";
+import { StyleSheet, Text, View } from "react-native";
+
+interface GroupMedicineCardProps {}
+
+const GroupMedicineCard = () => {
+  return (
+    <View>
+      <Text>GroupMedicineCard</Text>
+    </View>
+  );
+};
+
+export default GroupMedicineCard;
+
+const styles = StyleSheet.create({});

--- a/components/Card/NavigationCard.tsx
+++ b/components/Card/NavigationCard.tsx
@@ -8,7 +8,7 @@ import {
   Text,
   View,
 } from "react-native";
-import { ButtonStyles } from "./Styles/ButtonStyles.js";
+import { ButtonStyles } from "../Styles/ButtonStyles.js";
 
 interface NavigationCardProps extends PressableProps {
   text: string;

--- a/components/NavigationCard.tsx
+++ b/components/NavigationCard.tsx
@@ -1,0 +1,70 @@
+import { colors } from "@/constants/index";
+import AntDesign from "@expo/vector-icons/AntDesign";
+import { router } from "expo-router";
+import React from "react";
+
+import {
+  Pressable,
+  PressableProps,
+  StyleSheet,
+  Text,
+  View,
+} from "react-native";
+import { ButtonStyles } from "./Styles/ButtonStyles.js";
+
+interface NavigationCardProps extends PressableProps {
+  text: string;
+  icon?: "next" | "plus";
+}
+
+function NavigationCard({ text, icon = "next" }: NavigationCardProps) {
+  return (
+    <Pressable
+      style={({ pressed }) => [
+        NavigationCardStyles.container,
+        NavigationCardStyles[icon],
+        pressed && ButtonStyles.pressed,
+      ]}
+      onPress={() => router.push("/medicine/medicineList")}
+    >
+      <Text style={NavigationCardStyles.text}>{text}</Text>
+      <View style={NavigationCardStyles.iconBox}>
+        <AntDesign
+          name={icon == "next" ? "right" : "plus"}
+          size={12}
+          color="black"
+        />
+      </View>
+    </Pressable>
+  );
+}
+
+export default NavigationCard;
+
+const NavigationCardStyles = StyleSheet.create({
+  container: {
+    backgroundColor: colors.WHITE,
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    height: 50,
+    width: "45%",
+    borderRadius: 16,
+    paddingHorizontal: 15,
+    marginTop: 20,
+  },
+  text: {
+    fontWeight: "bold",
+    fontSize: 15,
+  },
+  next: {},
+  plus: {},
+  iconBox: {
+    backgroundColor: colors.PINK,
+    width: 25,
+    height: 25,
+    borderRadius: 10,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+});

--- a/components/NavigationCard.tsx
+++ b/components/NavigationCard.tsx
@@ -1,8 +1,6 @@
 import { colors } from "@/constants/index";
 import AntDesign from "@expo/vector-icons/AntDesign";
-import { router } from "expo-router";
 import React from "react";
-
 import {
   Pressable,
   PressableProps,
@@ -17,7 +15,11 @@ interface NavigationCardProps extends PressableProps {
   icon?: "next" | "plus";
 }
 
-function NavigationCard({ text, icon = "next" }: NavigationCardProps) {
+function NavigationCard({
+  text,
+  icon = "next",
+  ...props
+}: NavigationCardProps) {
   return (
     <Pressable
       style={({ pressed }) => [
@@ -25,7 +27,7 @@ function NavigationCard({ text, icon = "next" }: NavigationCardProps) {
         NavigationCardStyles[icon],
         pressed && ButtonStyles.pressed,
       ]}
-      onPress={() => router.push("/medicine/medicineList")}
+      {...props}
     >
       <Text style={NavigationCardStyles.text}>{text}</Text>
       <View style={NavigationCardStyles.iconBox}>

--- a/components/ScreenLayout.tsx
+++ b/components/ScreenLayout.tsx
@@ -1,0 +1,25 @@
+import { colors } from "@/constants";
+import React, { ReactNode } from "react";
+import { SafeAreaView, StyleSheet, View, ViewStyle } from "react-native";
+
+interface Props {
+  children: ReactNode;
+  style?: ViewStyle;
+}
+export const ScreenLayout = ({ children, style }: Props) => {
+  return (
+    <SafeAreaView style={[styles.background, style]}>
+      <View style={[styles.container, style]}>{children}</View>
+    </SafeAreaView>
+  );
+};
+
+const styles = StyleSheet.create({
+  background: {
+    flex: 1,
+    backgroundColor: colors.BG_COLOR,
+  },
+  container: {
+    marginHorizontal: 13,
+  },
+});

--- a/constants/index.ts
+++ b/constants/index.ts
@@ -6,6 +6,8 @@ const colors = {
   BACK_GRAY: "#EFF1F5",
   LIGHT_GRAY: "#EFF1F5",
   TEXT_GRAY: "#A09CAB",
+
+  BG_COLOR: "#F8F8F8",
 };
 
 export { colors };


### PR DESCRIPTION
## 📝 요약
약물 관리 메인의 페이지 이동을 구현

## 🔍 변경 사항
- 약물 관리 페이지 디렉토리 구조 설정
- 전체 복용 리스트 이동 버튼 생성
- 약물 등록 이동 버튼 생성

## 📋 체크리스트 
- [x] 전체 복용 리스트 이동 버튼 생성
- [x] 약물 등록 이동 버튼 생성


## 🔗 관련 이슈
Opens #8 
