### PR TITLE
♻️ [Refactor] 버튼 컴포넌트 사이즈 변경 및 아이콘을 추가한다.

### DIFF
--- a/components/Button.tsx
+++ b/components/Button.tsx
@@ -1,17 +1,20 @@
+import AntDesign from "@expo/vector-icons/AntDesign";
 import React from "react";
 import { Pressable, PressableProps, Text } from "react-native";
 import { ButtonStyles } from "./Styles/ButtonStyles.js";
 
 interface ButtonProps extends PressableProps {
-  text: string;
-  size?: "small" | "large";
+  text?: string;
+  size?: "small" | "medium" | "large";
   color?: "pink" | "gray";
+  icon?: "right" | "down" | null;
 }
 
 function Button({
   text,
   size = "large",
   color = "pink",
+  icon = null,
   ...props
 }: ButtonProps) {
   return (
@@ -24,7 +27,14 @@ function Button({
       ]}
       {...props}
     >
-      <Text>{text}</Text>
+      {icon && (
+        <AntDesign
+          name={icon == "right" ? "right" : "down"}
+          size={20}
+          color="black"
+        />
+      )}
+      {text && <Text>{text}</Text>}
     </Pressable>
   );
 }

--- a/components/Styles/ButtonStyles.js
+++ b/components/Styles/ButtonStyles.js
@@ -15,10 +15,8 @@ export const ButtonStyles = StyleSheet.create({
     width: "100%",
     height: 50,
   },
-  small: {
-    width: "50%",
-    height: 42,
-  },
+  medium: { width: "50%", height: 42 },
+  small: { width: 50, height: 37, borderRadius: 13 },
 
   pink: {
     backgroundColor: colors.PINK,
@@ -28,6 +26,8 @@ export const ButtonStyles = StyleSheet.create({
     backgroundColor: colors.BACK_GRAY,
     color: colors.BLACK,
   },
+  iconContainer: {},
+
   pressed: {
     opacity: 0.8,
   },


### PR DESCRIPTION
## 📝 요약
버튼 컴포넌트에 s사이즈 및 아이콘 추가

## 🔍 변경 사항
기존의 half 버튼을 medium으로 변경하고, 더 작은 small 버튼을 생성함.
small 버튼은 text가 아닌 아이콘이 필요하기 때문에 text 필수에서 제외, icon 속성 추가


## 📋 체크리스트 
- [x] small 버튼 생성
- [x] 아이콘 추가
- [x] text 필수 속성에서 제외


## 🔗 관련 이슈
Closes #8 
